### PR TITLE
Add support for custom limits on the order book depth endpoint

### DIFF
--- a/src/market.rs
+++ b/src/market.rs
@@ -13,12 +13,12 @@ pub struct Market {
     pub recv_window: u64,
 }
 
-// Market Data endpoints
+/// Market Data endpoints
 impl Market {
-    // Order book (Default 100; max 100)
+    /// Order book (Default 100; max 100)
     pub async fn get_depth<S>(&self, symbol: S) -> Result<OrderBook, BinanceErr>
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         let mut parameters: BTreeMap<String, String> = BTreeMap::new();
 
@@ -32,7 +32,26 @@ impl Market {
         Ok(order_book)
     }
 
-    // Latest price for ALL symbols.
+    /// Order book with a custom depth
+    /// Supported depths by binance: 5, 10, 20, 50, 100, 500, 1000, 5000
+    pub async fn get_custom_depth<S>(&self, symbol: S, limit: u16) -> Result<OrderBook, BinanceErr>
+    where
+        S: Into<String>,
+    {
+        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
+
+        parameters.insert("symbol".into(), symbol.into());
+        parameters.insert("limit".into(), limit.to_string());
+        let request = build_request(&parameters);
+
+        let data = self.client.get("/api/v3/depth", &request).await?;
+
+        let order_book: OrderBook = from_str(data.as_str())?;
+
+        Ok(order_book)
+    }
+
+    /// Latest price for ALL symbols.
     pub async fn get_all_prices(&self) -> Result<Prices, BinanceErr> {
         let data = self.client.get("/api/v3/ticker/price", "").await?;
 
@@ -41,10 +60,10 @@ impl Market {
         Ok(prices)
     }
 
-    // Latest price for ONE symbol.
+    /// Latest price for ONE symbol.
     pub async fn get_price<S>(&self, symbol: S) -> Result<SymbolPrice, BinanceErr>
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         let mut parameters: BTreeMap<String, String> = BTreeMap::new();
 
@@ -57,10 +76,10 @@ impl Market {
         Ok(symbol_price)
     }
 
-    // Average price for ONE symbol.
+    /// Average price for ONE symbol.
     pub async fn get_average_price<S>(&self, symbol: S) -> Result<AveragePrice, BinanceErr>
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         let mut parameters: BTreeMap<String, String> = BTreeMap::new();
 
@@ -73,8 +92,8 @@ impl Market {
         Ok(average_price)
     }
 
-    // Symbols order book ticker
-    // -> Best price/qty on the order book for ALL symbols.
+    /// Symbols order book ticker
+    /// -> Best price/qty on the order book for ALL symbols.
     pub async fn get_all_book_tickers(&self) -> Result<BookTickers, BinanceErr> {
         let data = self.client.get("/api/v3/ticker/bookTicker", "").await?;
 
@@ -83,26 +102,29 @@ impl Market {
         Ok(book_tickers)
     }
 
-    // -> Best price/qty on the order book for ONE symbol
+    /// -> Best price/qty on the order book for ONE symbol
     pub async fn get_book_ticker<S>(&self, symbol: S) -> Result<Tickers, BinanceErr>
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         let mut parameters: BTreeMap<String, String> = BTreeMap::new();
 
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get("/api/v3/ticker/bookTicker", &request).await?;
+        let data = self
+            .client
+            .get("/api/v3/ticker/bookTicker", &request)
+            .await?;
         let ticker: Tickers = from_str(data.as_str())?;
 
         Ok(ticker)
     }
 
-    // 24hr ticker price change statistics
+    /// 24hr ticker price change statistics
     pub async fn get_24h_price_stats<S>(&self, symbol: S) -> Result<PriceStats, BinanceErr>
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         let mut parameters: BTreeMap<String, String> = BTreeMap::new();
 
@@ -119,14 +141,19 @@ impl Market {
     // Returns up to 'limit' klines for given symbol and interval ("1m", "5m", ...)
     // https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#klinecandlestick-data
     pub async fn get_klines<S1, S2, S3, S4, S5>(
-        &self, symbol: S1, interval: S2, limit: S3, start_time: S4, end_time: S5,
+        &self,
+        symbol: S1,
+        interval: S2,
+        limit: S3,
+        start_time: S4,
+        end_time: S5,
     ) -> Result<KlineSummaries, BinanceErr>
-        where
-            S1: Into<String>,
-            S2: Into<String>,
-            S3: Into<Option<u16>>,
-            S4: Into<Option<u64>>,
-            S5: Into<Option<u64>>,
+    where
+        S1: Into<String>,
+        S2: Into<String>,
+        S3: Into<Option<u16>>,
+        S4: Into<Option<u64>>,
+        S5: Into<Option<u64>>,
     {
         let mut parameters: BTreeMap<String, String> = BTreeMap::new();
 


### PR DESCRIPTION
Hey there
the current `get_depth` method uses the default depth from binance which is quite low and I haven't seen another method that would allow to request it with a larger limit so I implemented a `get_custom_depth` method to not break the API of the already existing `get_depth` method.

I also ran rustfmt which changed the whitespacing of some methods. Don't know if it bothers you that much but I may use some different settings than you.